### PR TITLE
support 'git wip' when GIT_EXEC_PATH is a colon separated list

### DIFF
--- a/git-wip
+++ b/git-wip
@@ -37,11 +37,7 @@ Options for log:
 SUBDIRECTORY_OK=Yes
 OPTIONS_SPEC=
 
-if [ -r git-sh-setup ] ; then
-	. git-sh-setup
-else
-	. $(git --exec-path)/git-sh-setup || ( echo "git wip needs git to run." ; exit 1 )
-fi
+. git-sh-setup
 
 require_work_tree
 


### PR DESCRIPTION
Previously it was assumed that GIT_EXEC_PATH is a single directory.
This also removes support for calling the command with 'git-wip'.
Calling commands like this has been deprecated for a long time.
