### PR TITLE
Update Emacs integration and interaction with modern git.

### DIFF
--- a/emacs/git-wip-mode.el
+++ b/emacs/git-wip-mode.el
@@ -11,9 +11,9 @@
   (interactive)
   (when (git-wip-buffer-is-git-p)
     (start-process "git-wip" "*git-wip*"
-                   "git-wip" "save" (concat "WIP from emacs: "
-                                            (file-name-nondirectory
-                                            buffer-file-name))
+                   "git" "wip" "save" (concat "WIP from emacs: "
+                                              (file-name-nondirectory
+                                               buffer-file-name))
                    "--editor" "--"
                    (file-name-nondirectory buffer-file-name))
     (message (concat "Wrote and git-wip'd " (buffer-file-name)))))

--- a/emacs/git-wip-mode.el
+++ b/emacs/git-wip-mode.el
@@ -3,9 +3,13 @@
 
 (require 'vc)
 
+(defun git-wip-buffer-is-git-p ()
+  "Return true if the current buffer is managed by git, false otherwise."
+  (string= "git" (downcase (format "%s" (vc-backend (buffer-file-name))))))
+
 (defun git-wip-after-save ()
   (interactive)
-  (when (string= (vc-backend (buffer-file-name)) "Git")
+  (when (git-wip-buffer-is-git-p)
     (start-process "git-wip" "*git-wip*"
                    "git-wip" "save" (concat "WIP from emacs: "
                                             (file-name-nondirectory
@@ -35,7 +39,7 @@ you save a buffer."
 
 (defun git-wip-mode-if-git ()
   (interactive)
-  (when (string= (vc-backend (buffer-file-name)) "Git")
+  (when (git-wip-buffer-is-git-p)
     (git-wip-mode t)))
 
 (add-hook 'find-file-hook 'git-wip-mode-if-git)

--- a/git-wip
+++ b/git-wip
@@ -242,7 +242,7 @@ do_log () {
 
 	if ! wip_last=$(git rev-parse --quiet --verify $wip_branch)
 	then
-		die "'$work_branch' branch has no commits."
+		die "'$wip_branch' branch has no commits."
 	fi
 
 	dbg wip_last=$wip_last

--- a/git-wip
+++ b/git-wip
@@ -15,7 +15,7 @@
 # Please see http://www.gnu.org/licenses/gpl-2.0.txt
 #
 
-USAGE='[ info | save <message> [ --editor | --untracked ] | log [ --pretty ] | delete ] [ [--] <file>... ]'
+USAGE='[ info | save <message> [ --editor | --only-tracked ] | log [ --pretty ] | delete ] [ [--] <file>... ]'
 LONG_USAGE="Manage Work In Progress branches
 
 Commands:
@@ -27,7 +27,7 @@ Commands:
 
 Options for save:
         -e --editor               - be less verbose, assume called from an editor
-        -u --untracked            - capture also untracked files
+        -t --only-tracked         - only capture untracked files
         -i --ignored              - capture also ignored files
 
 Options for log:
@@ -120,7 +120,7 @@ build_new_tree () {
 
 do_save () {
 	local msg="$1" ; shift
-	local add_untracked=
+	local add_untracked=t
 	local add_ignored=
 
 	while test $# != 0
@@ -129,8 +129,8 @@ do_save () {
 		-e|--editor)
 			EDITOR_MODE=true
 			;;
-		-u|--untracked)
-			add_untracked=t
+		-t|--only-tracked)
+			add_untracked=
 			;;
 		-i|--ignored)
 			add_ignored=t

--- a/vim/plugin/git-wip.vim
+++ b/vim/plugin/git-wip.vim
@@ -7,6 +7,17 @@ endif
 
 function! GitWipSave()
         let dir = expand("%:p:h")
+        let show_cdup = system('cd ' . dir . ' && git rev-parse --show-cdup 2>/dev/null')
+        if v:shell_error
+            " We're not editing a file anywhere near a .git repository, so abort
+            return
+        endif
+        let show_cdup_len = len( show_cdup )
+        if show_cdup_len == 0
+            " We're editing a file in the .git directory
+            " (.git/EDIT_COMMITMSG, .git/config, etc.), so abort
+            return
+        endif
         let file = expand("%:t")
         let out = system('cd ' . dir . ' && git wip save "WIP from vim (' . file . ')" --editor -- "' . file . '" 2>&1')
         let err = v:shell_error


### PR DESCRIPTION
This updates the code, based on next, to work with Emacs 23.1, and to work with a modern git through invoking `git wip` rather than `git-wip` directly.

As a bonus, it has a minor fix to error reporting for `git wip log`.
