### PR TITLE
save explicitly specified files even if they are ignored by git

### DIFF
--- a/git-wip
+++ b/git-wip
@@ -107,7 +107,7 @@ build_new_tree () {
 	git read-tree $wip_parent
 	if [ -n "$files" ]
 	then
-		git add $files
+		git add -f $files
 	else
 		git add -u
 	fi


### PR DESCRIPTION
`magit-wip.el` (part of https://github.com/magit/magit) did not check whether git ignores the file being saved before calling `git wip save ...`. I created a patch (https://github.com/magit/magit/pull/614) to fix that but it hasn't been merged yet. Also I consider adding an option that would allow users to choose whether such files should be tracked in the wip branch or not.

Currently `git-wip` does not support adding a specific ignored file to the wip branch. The `--ignored` option only works when no file is specified explicitly. I think it makes sense to always add explicitly specified but ignored files without requiring the `--ignored` to be specified. In my eyes the file being specified explicitly should be enough reason to believe the caller actually wants it added.