### PR TITLE
sublime: Fix plugin (was not working)

### DIFF
--- a/sublime/gitwip.py
+++ b/sublime/gitwip.py
@@ -1,6 +1,6 @@
 import sublime_plugin
 from subprocess import Popen, PIPE, STDOUT
-from os import path
+import os
 import sublime
 import copy
 
@@ -13,8 +13,8 @@ class GitWipAutoCommand(sublime_plugin.EventListener):
     self.dirdata = None
 
   def on_post_save_async(self, view):
-    #(dirname, fname) = path.split(view.file_name())
-    self.dirdata = path.split(view.file_name())
+    #(dirname, fname) = os.path.split(view.file_name())
+    self.dirdata = os.path.split(view.file_name())
 
     if self.p is None:      
       self.apply_git()

--- a/sublime/gitwip.py
+++ b/sublime/gitwip.py
@@ -5,53 +5,28 @@ import sublime
 import copy
 
 class GitWipAutoCommand(sublime_plugin.EventListener):
-  """docstring for GitWipPlugin"""
 
-  def __init__(self):
-    super(GitWipAutoCommand, self).__init__()
-    self.p = None
-    self.dirdata = None
+    def on_post_save_async(self, view):
+        dirname, fname = os.path.split(view.file_name())
 
-  def on_post_save_async(self, view):
-    #(dirname, fname) = os.path.split(view.file_name())
-    self.dirdata = os.path.split(view.file_name())
+        p = Popen(["git", "wip", "save",
+                   "WIP from ST3: saving %s" % fname,
+                   "--editor", "--", fname],
+                  cwd=dirname, universal_newlines=True,
+                  bufsize=8096, stdout=PIPE, stderr=STDOUT)
 
-    if self.p is None:      
-      self.apply_git()
-    else:
-      print("git command is still running")      
-      
+        def finish_callback():
+            rcode = p.poll()
 
-  def finish_callback(self):    
-    p = self.p
-    if p is None:
-      return
+            if rcode is None: # not terminated yet
+                sublime.set_timeout_async(finish_callback, 20)
+                return
 
-    if p.poll() is None: #not terminated yet
-      sublime.set_timeout_async(lambda: self.finish_callback(), 20)
-    else:
+            if rcode != 0:
+                print ("git command returned code {}".format(rcode))
 
-      rcode = p.returncode
-      
-      if rcode != 0:
-        print ("git command error -> return code: %d" % rcode)
-        for line in p.stdout:
-          print(line)
+            for line in p.stdout:
+                print(line)
 
-      if self.dirdata is not None:
-        apply_git(self)
-      else:
-        self.p = None
-    
-    
+        finish_callback()
 
-  def apply_git(self):
-    (dirname, fname) = self.dirdata
-    self.dirdata = None
-    myenv = copy.copy(os.environ)
-    myenv["PATH"] = "/usr/local/bin:" + myenv["PATH"]
-    self.p = Popen(["git", "wip", "save", "WIP from ST3: saving %s" % fname, "--editor", "--", fname], 
-      cwd=dirname, bufsize=8096, stdout=PIPE, stderr=STDOUT, env=myenv)
-    sublime.set_timeout_async(lambda: self.finish_callback(), 20)
-  
-    


### PR DESCRIPTION
Fixes an error on `copy,copy(os.environ)` line.
Also use explicit `os.path` insead of doing `from os import path`.