### PR TITLE
Allow gpg commit signing to be disabled

### DIFF
--- a/git-wip
+++ b/git-wip
@@ -15,7 +15,7 @@
 # Please see http://www.gnu.org/licenses/gpl-2.0.txt
 #
 
-USAGE='[ info | save <message> [ --editor | --untracked ] | log [ --pretty ] | delete ] [ [--] <file>... ]'
+USAGE='[ info | save <message> [ --editor | --untracked | --no-gpg-sign ] | log [ --pretty ] | delete ] [ [--] <file>... ]'
 LONG_USAGE="Manage Work In Progress branches
 
 Commands:
@@ -29,6 +29,8 @@ Options for save:
         -e --editor               - be less verbose, assume called from an editor
         -u --untracked            - capture also untracked files
         -i --ignored              - capture also ignored files
+        --no-gpg-sign             - do not sign commit; that is, countermand
+                                    'commit.gpgSign = true'
 
 Options for log:
         -p --pretty               - show a pretty graph
@@ -124,6 +126,7 @@ do_save () {
 	local msg="$1" ; shift
 	local add_untracked=
 	local add_ignored=
+	local no_sign=
 
 	while test $# != 0
 	do
@@ -136,6 +139,9 @@ do_save () {
 			;;
 		-i|--ignored)
 			add_ignored=t
+			;;
+		--no-gpg-sign)
+			no_sign=--no-gpg-sign
 			;;
 		--)
 			shift
@@ -206,7 +212,7 @@ do_save () {
 
 	dbg "... has changes"
 
-	new_wip=$(printf '%s\n' "$msg" | git commit-tree $new_tree -p $wip_parent) \
+	new_wip=$(printf '%s\n' "$msg" | git commit-tree $no_sign $new_tree -p $wip_parent 2>/dev/null) \
 	|| die "Cannot record working tree state"
 
 	dbg "new_wip=$new_wip"

--- a/vim/plugin/git-wip.vim
+++ b/vim/plugin/git-wip.vim
@@ -4,10 +4,17 @@
 if !exists('g:git_wip_verbose')
         let g:git_wip_verbose = 0
 endif
+if !exists('g:git_wip_disable_signing')
+        let g:git_wip_disable_signing = 0
+endif
 
 function! GitWipSave()
         if expand("%") == ".git/COMMIT_EDITMSG"
             return
+        endif
+        let wip_opts = '--editor'
+        if g:git_wip_disable_signing
+            let wip_opts .= ' --no-gpg-sign'
         endif
         let out = system('git rev-parse 2>&1')
         if v:shell_error
@@ -26,7 +33,7 @@ function! GitWipSave()
             return
         endif
         let file = expand("%:t")
-        let out = system('cd ' . dir . ' && git wip save "WIP from vim (' . file . ')" --editor -- "' . file . '" 2>&1')
+        let out = system('cd ' . dir . ' && git wip save "WIP from vim (' . file . ')" ' . wip_opts . ' -- "' . file . '" 2>&1')
         let err = v:shell_error
         if err
                 redraw


### PR DESCRIPTION
With 'commit.gpgSign = true', git will sign all commits, including those made
via commit-tree.  This is good -- except that when git-wip is invoked from an
editor this often results in a mess on one's screen from a "You need a
passphrase to unlock your secret key..." message.

Unfortunately, git does not appear to have any way to pass "--batch" or other
options to gpg.  It does, however, allow commands to be called with
'--no-gpg-sign' in order to override the global "sign all the commits!"
configuration.

This commit allows one to disable commit signing for WIP commits by adding a
'--no-gpg-sign' option to git-wip.  It also adds a check for
g:git_wip_disable_signing to the vim plugin; if true it causes git-wip to be
called with the new --no-gpg-sign flag.
