### PR TITLE
git-wip uses bash features - therefore run in bash

### DIFF
--- a/git-wip
+++ b/git-wip
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright Bart Trojanowski <bart@jukie.net>
 # 


### PR DESCRIPTION
Was erroring on my machine with
```
/home/andrew/.local/bin/git-wip: 204: /home/andrew/.local/bin/git-wip: Bad substitution
Cannot save the current worktree state.
```
Running with bash fixes it